### PR TITLE
Referencing System.Drawing

### DIFF
--- a/src/MessageCore/VVVV.Packs.Messaging.Core.csproj
+++ b/src/MessageCore/VVVV.Packs.Messaging.Core.csproj
@@ -68,6 +68,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />

--- a/src/SpreadOperations/VVVV.Nodes.Generic.itl.csproj
+++ b/src/SpreadOperations/VVVV.Nodes.Generic.itl.csproj
@@ -38,6 +38,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Drawing.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.ComponentModel.Composition.CodePlex">

--- a/src/Tests/VVVV.Packs.Messaging.Tests.csproj
+++ b/src/Tests/VVVV.Packs.Messaging.Tests.csproj
@@ -57,6 +57,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Drawing.dll</HintPath>
+    </Reference>
     <Reference Include="System.XML" />
     <Reference Include="VVVV.Core, Version=34.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VVVV.Core.34.2.0\lib\net40\VVVV.Core.dll</HintPath>


### PR DESCRIPTION
Little fix which fixes the compiler complaining about missing System.Drawing reference. Now messages can be compiled automatically.