### PR TITLE
Updated vpack with a better script

### DIFF
--- a/copy/.vpack
+++ b/copy/.vpack
@@ -1,15 +1,13 @@
 <vpack>
   <meta>
     <name>vvvv-Message</name>
-    <source>https://github.com/velcrome/vvvv-Message.git</source>
+    <source></source>
     <author>velcrome</author>
-    <dependencies>
-    </dependencies>
   </meta>
   <install>
-	GitClone("https://github.com/velcrome/vvvv-Message.git", Pack.TempDir);
+	GitClone("https://github.com/velcrome/vvvv-Message.git", Pack.TempDir, branch: "beta35");
 
-	BuildSolution(2013, Pack.TempDir + "\\src\\vvvv-Message.sln", "Release|" + VVVV.Architecture, true);
+	BuildSolution(2015, Pack.TempDir + "\\src\\vvvv-Message.sln", "Release|" + VVVV.Architecture, true);
 
 	CopyDir(
 	    Pack.TempDir + "\\build\\" + VVVV.Architecture + "\\Release",


### PR DESCRIPTION
Source is not specified now, instead cloning is done in script so you can select a branch which I presume is beta35. Also automatic building is only working for me in VS 2015, VS 2013 still misses the system.drawing reference, which is no problem just use 2015. Selecting branches in source will probably come with the format of https://github.com/velcrome/vvvv-Message.git:beta35 until then we should use script