### PR TITLE
Updated vpack

### DIFF
--- a/copy/.vpack
+++ b/copy/.vpack
@@ -5,14 +5,10 @@
     <author>velcrome</author>
   </meta>
   <install>
-	GitClone("https://github.com/velcrome/vvvv-Message.git", Pack.TempDir, branch: "beta35");
+	GitClone("https://github.com/velcrome/vvvv-Message.git", Pack.TempDir);
 
-	BuildSolution(2015, Pack.TempDir + "\\src\\vvvv-Message.sln", "Release|" + VVVV.Architecture, true);
+        BuildSolution(2015, Pack.TempDir + "\\src\\vvvv-Message.sln", "Release|AnyCPU", true);
 
-	CopyDir(
-	    Pack.TempDir + "\\build\\" + VVVV.Architecture + "\\Release",
-	    VVVV.Dir + "\\packs\\vvvv-Message"
-	);
 	CopyDir(
 	    Pack.TempDir + "\\build\\AnyCPU\\Release",
 	    VVVV.Dir + "\\packs\\vvvv-Message"


### PR DESCRIPTION
it looks like messages became AnyCPU only, adapted vpack script to it because it began to fail for me, also GitClone now referencing master branch, for beta35 branch if you want you can add `branch: "beta35"` at the end of GitClone(...)